### PR TITLE
Added a clipping path with same shape as background

### DIFF
--- a/progressview/src/main/java/com/skydoves/progressview/ProgressView.kt
+++ b/progressview/src/main/java/com/skydoves/progressview/ProgressView.kt
@@ -21,6 +21,9 @@ package com.skydoves.progressview
 import android.animation.ValueAnimator
 import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.Canvas
+import android.graphics.Path
+import android.graphics.RectF
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
@@ -114,6 +117,8 @@ class ProgressView : FrameLayout {
       this.highlightView.onProgressClickListener = value
     }
 
+  private val path = Path()
+
   constructor(context: Context) : super(context)
 
   constructor(context: Context, attributeSet: AttributeSet) : super(context, attributeSet) {
@@ -187,6 +192,20 @@ class ProgressView : FrameLayout {
   override fun onFinishInflate() {
     super.onFinishInflate()
     updateProgressView()
+  }
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    path.apply {
+      reset()
+      addRoundRect(RectF(0f, 0f, w.toFloat(), h.toFloat()), floatArrayOf(radius, radius, radius, radius, radius, radius, radius, radius), Path.Direction.CCW)
+    }
+
+  }
+
+  override fun dispatchDraw(canvas: Canvas) {
+    canvas.clipPath(path)
+    super.dispatchDraw(canvas)
   }
 
   private fun updateProgressView() {

--- a/progressview/src/main/java/com/skydoves/progressview/ProgressView.kt
+++ b/progressview/src/main/java/com/skydoves/progressview/ProgressView.kt
@@ -200,7 +200,6 @@ class ProgressView : FrameLayout {
       reset()
       addRoundRect(RectF(0f, 0f, w.toFloat(), h.toFloat()), floatArrayOf(radius, radius, radius, radius, radius, radius, radius, radius), Path.Direction.CCW)
     }
-
   }
 
   override fun dispatchDraw(canvas: Canvas) {


### PR DESCRIPTION
Added a clipping path with same shape as background restricting highlight view inside background.
It fixes the issue #1 

Screenshot before the change
![Screenshot_1570034827](https://user-images.githubusercontent.com/1777963/66064894-f0717080-e563-11e9-814a-2dfd32df7f8d.png)

Screenshot after the change
![Screenshot_1570034931](https://user-images.githubusercontent.com/1777963/66064918-fd8e5f80-e563-11e9-9070-a99e3db30a21.png)


## Guidelines
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

### Types of changes
What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.