### PR TITLE
added option for setting up different corner radius for each corner o…

### DIFF
--- a/app/src/main/java/com/skydoves/progressviewdemo/CustomActivity.kt
+++ b/app/src/main/java/com/skydoves/progressviewdemo/CustomActivity.kt
@@ -47,6 +47,7 @@ class CustomActivity : AppCompatActivity() {
       progressView5.setOnProgressChangeListener { progressView5.labelText = "${it.toInt()}%" }
 
       progressView.progressFromPrevious = true
+      progressView.radiusCollection = floatArrayOf(0f, 0f, 0f, 0f, 50f, 50f, 50f, 50f)
 
       progressView3.setOnProgressClickListener {
         if (it) {

--- a/app/src/main/res/layout/activity_custom.xml
+++ b/app/src/main/res/layout/activity_custom.xml
@@ -154,7 +154,7 @@
         app:progressView_orientation="vertical"
         app:progressView_padding="1.5dp"
         app:progressView_progress="45"
-        app:progressView_radius="13dp" />
+        app:progressView_radius="70dp" />
     </LinearLayout>
   </LinearLayout>
 

--- a/progressview/src/main/java/com/skydoves/progressview/HighlightView.kt
+++ b/progressview/src/main/java/com/skydoves/progressview/HighlightView.kt
@@ -64,6 +64,13 @@ class HighlightView(
   var radius: Float = dp2Px(5).toFloat()
     set(value) {
       field = value
+      radiusCollection = floatArrayOf(value, value, value, value, value, value, value, value)
+      updateHighlightView()
+    }
+
+  var radiusCollection: FloatArray = floatArrayOf(5F, 5F, 5F, 5F, 5F, 5F, 5F, 5F)
+    set(value) {
+      field = value
       updateHighlightView()
     }
 
@@ -130,11 +137,11 @@ class HighlightView(
         gradientOrientation,
         intArrayOf(colorGradientStart, colorGradientEnd)
       ).apply {
-        cornerRadius = radius
+        cornerRadii = radiusCollection
       }
     } else if (highlight == null) {
       GradientDrawable().apply {
-        cornerRadius = radius
+        cornerRadii = radiusCollection
         setColor(this@HighlightView.color)
       }
     } else {
@@ -146,7 +153,7 @@ class HighlightView(
   private fun updateStrokeView() {
     strokeView.background = GradientDrawable().apply {
       setColor(Color.TRANSPARENT)
-      cornerRadius = radius
+      cornerRadii = radiusCollection
       setStroke(highlightThickness, highlightColor)
     }
     strokeView.applyMargin()

--- a/progressview/src/main/java/com/skydoves/progressview/ProgressView.kt
+++ b/progressview/src/main/java/com/skydoves/progressview/ProgressView.kt
@@ -142,6 +142,14 @@ class ProgressView : FrameLayout {
   @Px var radius: Float = dp2Px(5).toFloat()
     set(value) {
       field = value
+      radiusCollection = floatArrayOf(value, value, value, value, value, value, value, value)
+      updateBackground()
+    }
+
+  var radiusCollection = floatArrayOf(5F, 5F, 5F, 5F, 5F, 5F, 5F, 5F)
+    set(value) {
+      field = value
+      highlightView.radiusCollection = value
       updateBackground()
     }
 
@@ -344,6 +352,7 @@ class ProgressView : FrameLayout {
       colorGradientEnd =
         a.getColor(R.styleable.ProgressView_progressView_colorGradientEnd, NO_COLOR)
       radius = this@ProgressView.radius
+      radiusCollection = this@ProgressView.radiusCollection
       padding =
         a.getDimension(R.styleable.ProgressView_progressView_padding, borderWidth.toFloat()).toInt()
       highlightColor =
@@ -384,7 +393,7 @@ class ProgressView : FrameLayout {
       reset()
       addRoundRect(
         RectF(0f, 0f, w.toFloat(), h.toFloat()),
-        floatArrayOf(radius, radius, radius, radius, radius, radius, radius, radius),
+        floatArrayOf(radiusCollection[0], radiusCollection[1], radiusCollection[2], radiusCollection[3], radiusCollection[4], radiusCollection[5], radiusCollection[6], radiusCollection[7]),
         Path.Direction.CCW
       )
     }
@@ -405,7 +414,7 @@ class ProgressView : FrameLayout {
 
   private fun updateBackground() {
     background = GradientDrawable().apply {
-      cornerRadius = radius
+      cornerRadii = radiusCollection
       setColor(colorBackground)
       setStroke(borderWidth, borderColor)
     }
@@ -633,8 +642,8 @@ class ProgressView : FrameLayout {
     fun setColorBackground(@ColorInt value: Int): Builder = apply {
       this.progressView.colorBackground = value
     }
-
     fun setRadius(@Px value: Float): Builder = apply { this.progressView.radius = value }
+    fun setRadii(value: FloatArray): Builder = apply { this.progressView.radiusCollection = value }
     fun setLabelText(value: CharSequence): Builder = apply { this.progressView.labelText = value }
     fun setLabelTextResource(@StringRes value: Int): Builder = apply {
       setLabelText(progressView.context.getString(value))
@@ -684,6 +693,10 @@ class ProgressView : FrameLayout {
 
     fun setProgressbarRadius(@Px value: Float): Builder = apply {
       this.progressView.highlightView.radius = value
+    }
+
+    fun setProgressbarRadii(value: FloatArray): Builder = apply {
+      this.progressView.highlightView.radiusCollection = value
     }
 
     fun setHighlightColor(@ColorInt value: Int): Builder = apply {


### PR DESCRIPTION
## Guidelines
In current version of ProgressView (i.e. version 1.1.0) there is only one option to set radius, by using it user can set same radius to all corners of ProfressView. So, now I have added another option, by using it user can set different corner radius to each corner of ProgressView.

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
